### PR TITLE
reorganize views for input_structure

### DIFF
--- a/webservice/run_app.py
+++ b/webservice/run_app.py
@@ -598,21 +598,12 @@ def process_structure_core(
 
 
 @app.route("/")
-def index():
-    """
-    Main view, redirect to input_structure
-    """
-    return flask.redirect(flask.url_for("input_structure"))
-
-
-@app.route("/")
-def input_data():
+def input_structure():
     """
     Main view, input data selection and upload
     """
-    print(**get_config())
     return flask.render_template(
-        get_visualizer_select_template(flask.request), **get_config()
+        get_visualizer_select_template(flask.request), version=__version__
     )
 
 
@@ -622,16 +613,6 @@ def termsofuse():
     View for the terms of use
     """
     return flask.send_from_directory(view_folder, "termsofuse.html")
-
-
-@app.route("/input_structure/")
-def input_structure():
-    """
-    Input structure selection
-    """
-    return flask.render_template(
-        get_visualizer_select_template(flask.request), version=__version__
-    )
 
 
 @app.route("/set_feature_importance_level/", methods=["GET", "POST"])


### PR DESCRIPTION
Dear Kevin,

I made the few changed to the views I proposed in my email (09 Feb). 
It seems this solved the problem of the http redirect we had on:
https://dev-www.materialscloud.org/work/tools/oximachine

Could you please check and merge these changes and re-deploy the oximachinetool on:
matcloud.xyz and materialscloud.io

Thank you for your help.
Best,
Valeria 